### PR TITLE
Add Linux udev rule & add information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ SNI is designed and implemented by **jsd1982** and was started in May 2021.
 
 Simply start `sni.exe` (Windows) or `./SNI` (MacOS/Linux) and leave it running.
 
-If you are using Linux and an SD2SNES hardware USB-enabled SNES cartridge, you will need to install the udev rule in `linux/udev/rules.d` and either reboot or reload udev.
+If you are using Linux and an SD2SNES hardware USB-enabled SNES cartridge, you will need to install the udev rule in `linux/udev/rules.d` and either reboot or reload udev. You will need root to do this.
 
-```$ sudo cp linux/udev/rules.d/51-fxpak.rules /etc/udev/rules.d/.
+```
+$ sudo cp linux/udev/rules.d/51-fxpak.rules /etc/udev/rules.d/.
 $ sudo udevadm control --reload
-$ sudo udevadm trigger```
+$ sudo udevadm trigger
+```
 
 SNI is intended to be easy to use with little to no direct user interaction. It should always Just Work™.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ SNI is designed and implemented by **jsd1982** and was started in May 2021.
 
 # For End Users
 
-Simply start `sni.exe` and leave it running.
+Simply start `sni.exe` (Windows) or `./SNI` (MacOS/Linux) and leave it running.
+
+If you are using Linux and an SD2SNES hardware USB-enabled SNES cartridge, you will need to install the udev rule in `linux/udev/rules.d` and either reboot or reload udev.
+
+```$ sudo cp linux/udev/rules.d/51-fxpak.rules /etc/udev/rules.d/.
+$ sudo udevadm control --reload
+$ sudo udevadm trigger```
 
 SNI is intended to be easy to use with little to no direct user interaction. It should always Just Work™.
 

--- a/linux/udev/rules.d/51-fxpak.rules
+++ b/linux/udev/rules.d/51-fxpak.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="5a22", MODE="0666"
+


### PR DESCRIPTION
This pull request adds a simple udev rule that assigns `0666` permissions to an FXPak Pro flashcart. This prevents Linux users from needing to launch SNI as root.

This also adds some text to README.md regarding the udev rule and how to install it.