### PR TITLE
Fix ls failing when end of string falls on 512 boundary

### DIFF
--- a/devices/snes/drivers/fxpakpro/ls.go
+++ b/devices/snes/drivers/fxpakpro/ls.go
@@ -110,8 +110,11 @@ recvLoop:
 			// file size does not come in this response
 			files = append(files, file)
 		}
-		if i >= 512 {
-			return nil, fmt.Errorf("ls: went through too many iterations")
+		if i == 512 {
+			if sb[i-1] != 0 {
+				return nil, fmt.Errorf("ls: malformed packet")
+			}
+			continue recvLoop
 		}
 	}
 


### PR DESCRIPTION
My device wasn't working with QFile2Snes, nor a GRPC replacement I started writing after blaming QFile2Snes for being jank. Turns out it's a bug with SNI. When I request files for my device, the first returned packet looks like this - 
```
 
01616c74747072202d204e6f476c6974636865732d6f70656e2d67616e6f6e5f34417670644b7a34766e2e7366630001616c74747072202d204e6f476c697463 
6865732d6f70656e2d67616e6f6e5f4f6247626450654476502e7366630001616c74747072202d204e6f476c6974636865732d6f70656e2d67616e6f6e5f6f4c
7956376b365947622e736663000150325f7a69675f47306a7a716d6c3854372d4c5a722d7a664d496649412e7366630001616c74747072202d204e6f476c6974
636865732d6f70656e2d67616e6f6e5f67564d5237716e6f76352e7366630001616c74747072202d204e6f476c6974636865732d6f70656e2d67616e6f6e5f5a
654d34346130614d6a202831292e73666300014c5454504861636b2d7631332e312e312d656d756c61746f722d637573746f6d6875642e7366630001424d5f4d 
37393838333831313939373932303334343138365f50325f7a69672e7366630001424d5f3639343230313333375f50325f5a69675f6e6f6c6f6769635f6e6f72
6d616c2d6e6f726d616c2d6f70656e2d67616e6f6e5f76616e696c6c612d62616c616e6365642e7366630001424d5f3639343230313333375f50325f5a69675f
6e6f6c6f6769635f6e6f726d616c2d6e6f726d616c2d6f70656e2d67616e6f6e5f76616e696c6c612d62616c616e6365642d6b657973616e6974792e73666300    
```
- it looks like reading a `0x02` for "there's more data here" is just an optimization and you really really need to just keep reading as long as you don't get `0xFF`. This patch appears to fix things for me locally.