### PR TITLE
Fix typo in README for grpcui

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ A great UI tool for ad-hoc testing of gRPC services is [grpcui](https://github.c
 
 To use `grpcui`, invoke it like this on the command line:
 
-```grpcui -plaintest -listen 8192 localhost:8191```
+```grpcui -plaintext localhost:8191```
 
 SNI has grpc reflection enabled to allow using such ad-hoc testing tools as `grpcui`.
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ A great UI tool for ad-hoc testing of gRPC services is [grpcui](https://github.c
 
 To use `grpcui`, invoke it like this on the command line:
 
-```grpcui -plaintext localhost:8191```
+```grpcui -plaintext -port 8192 localhost:8191```
+
+This will open the gRPC web UI at [localhost:8192](http://localhost:8192) and interface with SNI at localhost:8191.
 
 SNI has grpc reflection enabled to allow using such ad-hoc testing tools as `grpcui`.
 


### PR DESCRIPTION
First of all, thank you so much for this project. This has made interfacing with a SNES so much easier for me.

In getting started, I tried to run the `grpcui` command that was in the [README](/alttpo/sni/blob/main/README.md#generating-grpc-client-code) but was presented with an error saying that `plaintest` and `listen` weren't options. It looks like `plaintest` is a typo for `plaintext`. I couldn't find anything about the `listen` option, but I was able to run `grpcui` fine without it.