### PR TITLE
Use LUABRIDGE env vars in Connector.lua

### DIFF
--- a/lua/Connector.lua
+++ b/lua/Connector.lua
@@ -63,8 +63,8 @@ end
 local socket = require("socket.core")
 
 local connection
-local host = '127.0.0.1'
-local port = 65398
+local host = os.getenv("SNI_LUABRIDGE_LISTEN_HOST") or '127.0.0.1'
+local port = os.getenv("SNI_LUABRIDGE_LISTEN_PORT") or 65398
 local connected = false
 local stopped = false
 local name = "Unnamed"


### PR DESCRIPTION
When playing games that use SNI, oftentimes the default port that SNI uses is occupied by a client listener port from another app and SNI will refuse to work until I reboot to clear the client port.  I use the `SNI_LUABRIDGE_LISTEN_PORT` environment variable to get around this, but the Lua script doesn't use this environment variable by default.

This change allows me to set a specific port in my environment variables and have the Lua script work out of the box.

Tested in Windows, SNES9x rr with the SNI and Lua that ships with Archipelago 0.3.5.