### PR TITLE
CI: update Go and actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.22.1'
 
       - name: Set up linux dependencies
         run: sudo apt-get update && sudo apt-get install -y gcc libgtk-3-dev libayatana-appindicator3-dev
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -54,13 +54,13 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.22.1'
 
       - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-${{matrix.goos}}-${{matrix.goarch}}${{matrix.alt}}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
         with:
           fetch-depth: 0
@@ -110,7 +110,7 @@ jobs:
         run: 7z x -o"${{env.basename}}" "${{ runner.temp }}/${{ matrix.snfm }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.basename}}
           path: ${{env.basename}}/
@@ -144,13 +144,13 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.22.1'
 
       - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-darwin-universal${{matrix.alt}}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
         with:
           fetch-depth: 0
@@ -196,7 +196,7 @@ jobs:
         run: 7z x -o"${{env.basename}}" "${{ runner.temp }}/${{ matrix.snfm }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.basename}}
           path: ${{env.basename}}/
@@ -267,7 +267,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.22.1'
 
@@ -276,7 +276,7 @@ jobs:
 
       - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-${{matrix.goos}}-${{matrix.goarch}}${{matrix.alt}}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
         with:
           fetch-depth: 0
@@ -318,7 +318,7 @@ jobs:
         run: 7z x -o"${{env.basename}}" "${{ runner.temp }}/${{ matrix.snfm }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.basename}}
           path: ${{env.basename}}/
@@ -345,7 +345,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v4  # @v5 does not work with manylinux2014 glibc
         with:
           go-version: '^1.22.1'
 
@@ -356,7 +356,7 @@ jobs:
 
       - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-manylinux2014-amd64" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3  # @v4 does not work with manylinux2014 glibc
         name: Checkout
         with:
           fetch-depth: 0
@@ -399,14 +399,14 @@ jobs:
           tar cJf ${{env.basename}}.tar.xz ${{env.basename}}/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3  # @v4 does not work with manylinux2014 glibc
         with:
           name: ${{env.basename}}.tar.xz
           path: ${{github.workspace}}/${{env.basename}}.tar.xz
 
       - name: Upload binaries to release
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@2.7.0  # @2.8.0 probably does not work with manylinux2014 glibc
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.GITHUB_REF_SLUG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '^1.22.1'
 
       - name: Set up linux dependencies
         run: sudo apt-get update && sudo apt-get install -y gcc libgtk-3-dev libayatana-appindicator3-dev
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '^1.22.1'
 
       - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-${{matrix.goos}}-${{matrix.goarch}}${{matrix.alt}}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '^1.22.1'
 
       - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-darwin-universal${{matrix.alt}}" >> $GITHUB_ENV
 
@@ -269,7 +269,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '^1.22.1'
 
       - name: Set up linux dependencies
         run: sudo apt-get update && sudo apt-get install -y gcc ${{matrix.linuxdeps}}
@@ -347,7 +347,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '^1.22.1'
 
       - name: Set up linux dependencies
         run: |


### PR DESCRIPTION
Go 1.22.1 Seems to work now. It's also probably better to fail than using an "outdated" version by accident.

Also updates the actions to avoid warnings for outdated node. Should all be compatible with the exception of manylinux2014. Latest node does not work there anymore. manylinux2014 will go EOL June 30, 2024.