### PR TITLE
Fix manylinux build not finding .so files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,13 +398,18 @@ jobs:
       - name: Build SNI
         run: >
           CGO_ENABLED=1
-          CGO_LDFLAGS="$CGO_LDFLAGS -Wl,-rpath=. -Wl,--gc-sections"
+          CGO_LDFLAGS="$CGO_LDFLAGS -Wl,-rpath=\$ORIGIN -Wl,--gc-sections"
           GOARCH=amd64
           go build -tags=legacy_appindicator -buildvcs=false
           -gcflags=all=-l
           -ldflags="-w -X 'main.version=${{env.GITHUB_REF_SLUG}}' -X 'main.commit=${{env.GITHUB_SHA_SHORT}}' -X 'main.date=$(date +'%Y-%m-%dT%H:%M:%S')'"
           -o ./${{env.basename}}/sni
           ./cmd/sni
+
+      - name: Patch appindicator rpath
+        run: |
+          dnf -y install patchelf
+          patchelf --force-rpath --set-rpath '$ORIGIN' ./${{env.basename}}/libappindicator3.*
 
       - name: Package ${{env.basename}}.tar.xz for Linux
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,14 +417,14 @@ jobs:
           tar cJf ${{env.basename}}.tar.xz ${{env.basename}}/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3  # @v4 does not work with manylinux2014 glibc
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.basename}}.tar.xz
           path: ${{github.workspace}}/${{env.basename}}.tar.xz
 
       - name: Upload binaries to release
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
-        uses: svenstaro/upload-release-action@2.7.0  # @2.8.0 probably does not work with manylinux2014 glibc
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.GITHUB_REF_SLUG }}


### PR DESCRIPTION
* Properly sets rpath for the manylinux build to find libappindicator
* Patches libappindicator rpath so it finds libindicator
* Update actions now that we use a newer manylinux image to build that can run current node

Tested here: https://github.com/black-sliver/sni/actions/runs/12026877741/job/33526733929#step:11:1 (ldd shows the correct paths))
and locally by running the build in a mostly-fresh Ubuntu 24.04 VM that has neither appindicator nor indicator installed.