### PR TITLE
Allow environment variables to be set through the config file

### DIFF
--- a/cmd/sni/config/config.go
+++ b/cmd/sni/config/config.go
@@ -29,8 +29,6 @@ var (
 	VerboseLogging bool = false
 	LogResponses   bool = false
 	ShowConsole    bool = false
-	// SniDebug       bool = false
-	// SniDebugParsed bool = false // ShowConsole    bool = false
 )
 
 var (

--- a/cmd/sni/config/config.go
+++ b/cmd/sni/config/config.go
@@ -2,13 +2,14 @@ package config
 
 import (
 	"fmt"
-	"github.com/alttpo/observable"
-	"github.com/fsnotify/fsnotify"
-	"github.com/spf13/viper"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/alttpo/observable"
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -27,6 +28,8 @@ var (
 	VerboseLogging bool = false
 	LogResponses   bool = false
 	ShowConsole    bool = false
+	SniDebug       bool = false
+	SniDebugParsed bool = false // ShowConsole    bool = false
 )
 
 var (
@@ -98,6 +101,9 @@ func loadConfig() {
 	Config.WatchConfig()
 
 	ReloadConfig()
+	VerboseLogging = Config.GetBool("verboseLogging")
+	LogResponses = Config.GetBool("logResponses")
+	SniDebug = Config.GetBool("sni_debug")
 }
 
 func ReloadConfig() {

--- a/cmd/sni/config/config.go
+++ b/cmd/sni/config/config.go
@@ -56,8 +56,8 @@ var (
 		"retroarch_hosts":      "localhost:55355",
 		"retroarch_detect_log": false,
 
-		"luabrigde_listen_host": "127.0.0.1",
-		"luabrigde_listen_port": 65398,
+		"luabridge_listen_host": "127.0.0.1",
+		"luabridge_listen_port": 65398,
 
 		"mock_enable": false,
 
@@ -182,14 +182,14 @@ func bindConfigEnv() {
 	for key := range sniConfigs {
 		err := Config.BindEnv(key)
 		if err != nil {
-			fmt.Printf("Error Binding environment variable %v: %v\n", key, err)
+			log.Printf("Error Binding environment variable %v: %v\n", key, err)
 		}
 	}
 
 	// As stated previously, the variable associated with SNI_EMUNW_HOSTS it set dynamically later, if not bound bound in this stage
 	err := Config.BindEnv("emunw_hosts")
 	if err != nil {
-		fmt.Printf("Error Binding environment variable SNI_EMUNW_HOSTS: %v\n", err)
+		log.Printf("Error Binding environment variable SNI_EMUNW_HOSTS: %v\n", err)
 	}
 
 	/*
@@ -200,7 +200,7 @@ func bindConfigEnv() {
 	for key := range nwaConfigs {
 		err := Config.BindEnv(key, strings.ToUpper(key))
 		if err != nil {
-			fmt.Printf("Error Binding environment variable %v: %v\n", key, err)
+			log.Printf("Error Binding environment variable %v: %v\n", key, err)
 		}
 	}
 }

--- a/cmd/sni/config/config.go
+++ b/cmd/sni/config/config.go
@@ -59,6 +59,8 @@ var (
 		"luabrigde_listen_host": "127.0.0.1",
 		"luabrigde_listen_port": 65398,
 
+		"mock_enable": false,
+
 		// sni_emunw_hosts is set dynamically when initializing the driver and initialization is conditioned on nwa_disable_old_range
 		// We are not setting it here
 		"emunw_disable":    false,
@@ -191,10 +193,10 @@ func bindConfigEnv() {
 	}
 
 	/*
-		   * Parse NWA related env variable, stated as not starting with "SNI_"
-			 * Viper BindEnv() will allow to use these even if they are set up with "SNI_"
-			 * In this case, for example, viper will associate both "SNI_NWA_PORT_RANGE" and "NWA_PORT_RANGE", the later taking precedance
-	*/
+	* Parse NWA related env variable, stated as not starting with "SNI_"
+	* Viper BindEnv() will allow to use these even if they are set up with "SNI_"
+	* In this case, for example, viper will associate both "SNI_NWA_PORT_RANGE" and "NWA_PORT_RANGE", the later taking precedance
+	 */
 	for key := range nwaConfigs {
 		err := Config.BindEnv(key, strings.ToUpper(key))
 		if err != nil {

--- a/cmd/sni/tray/tray.go
+++ b/cmd/sni/tray/tray.go
@@ -5,9 +5,6 @@ package tray
 
 import (
 	"fmt"
-	"github.com/alttpo/observable"
-	"github.com/alttpo/systray"
-	"github.com/spf13/viper"
 	"log"
 	"runtime"
 	"sni/cmd/sni/appversion"
@@ -18,6 +15,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/alttpo/observable"
+	"github.com/alttpo/systray"
+	"github.com/spf13/viper"
 )
 
 const maxItems = 10
@@ -48,7 +49,7 @@ func UpdateDeviceList(deviceDescriptors []devices.DeviceDescriptor) {
 
 		deviceMenuItems[i].SetTitle(desc.DisplayName)
 		deviceMenuItems[i].SetTooltip(desc.Kind)
-		//deviceMenuItems[i].Check()
+		// deviceMenuItems[i].Check()
 		deviceMenuItems[i].Show()
 	}
 
@@ -114,7 +115,7 @@ func trayStart() {
 	systray.AddSeparator()
 
 	var toggleShowConsole *systray.MenuItem
-	var updateConsole = func() {
+	updateConsole := func() {
 		if toggleShowConsole != nil {
 			if config.ShowConsole {
 				toggleShowConsole.Check()
@@ -152,14 +153,12 @@ func trayStart() {
 			return
 		}
 
-		config.VerboseLogging = v.GetBool("verboseLogging")
 		if config.VerboseLogging {
 			toggleVerbose.Check()
 		} else {
 			toggleVerbose.Uncheck()
 		}
 
-		config.LogResponses = v.GetBool("logResponses")
 		if config.LogResponses {
 			toggleLogResponses.Check()
 		} else {

--- a/devices/autocloseabledevice.go
+++ b/devices/autocloseabledevice.go
@@ -46,12 +46,7 @@ func NewAutoCloseableDevice(container DeviceContainer, uri *url.URL, deviceKey s
 	if uri == nil {
 		panic(fmt.Errorf("uri cannot be nil"))
 	}
-
-	// if config.SniDebugParsed {
-	// 	config.SniDebug = util.IsTruthy(env.GetOrDefault("SNI_DEBUG", "0"))
-	// 	config.SniDebugParsed = true
-	// }
-
+	
 	var logger *log.Logger
 	if config.Config.GetBool("debug") {
 		defaultLogger := log.Default()

--- a/devices/autocloseabledevice.go
+++ b/devices/autocloseabledevice.go
@@ -3,13 +3,13 @@ package devices
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/codes"
 	"io"
 	"log"
 	"net/url"
+	"sni/cmd/sni/config"
 	"sni/protos/sni"
-	"sni/util"
-	"sni/util/env"
+
+	"google.golang.org/grpc/codes"
 )
 
 // AutoCloseableDevice is a Device wrapper that ensures that a valid Device instance is always used for every
@@ -34,10 +34,10 @@ type autoCloseableDevice struct {
 	logger *log.Logger
 }
 
-var (
-	sniDebug       bool
-	sniDebugParsed bool
-)
+// var (
+// 	sniDebug       bool
+// 	sniDebugParsed bool
+// )
 
 func NewAutoCloseableDevice(container DeviceContainer, uri *url.URL, deviceKey string) AutoCloseableDevice {
 	if container == nil {
@@ -47,13 +47,13 @@ func NewAutoCloseableDevice(container DeviceContainer, uri *url.URL, deviceKey s
 		panic(fmt.Errorf("uri cannot be nil"))
 	}
 
-	if !sniDebugParsed {
-		sniDebug = util.IsTruthy(env.GetOrDefault("SNI_DEBUG", "0"))
-		sniDebugParsed = true
-	}
+	// if config.SniDebugParsed {
+	// 	config.SniDebug = util.IsTruthy(env.GetOrDefault("SNI_DEBUG", "0"))
+	// 	config.SniDebugParsed = true
+	// }
 
 	var logger *log.Logger
-	if sniDebug {
+	if config.SniDebug {
 		defaultLogger := log.Default()
 		logger = log.New(
 			defaultLogger.Writer(),

--- a/devices/autocloseabledevice.go
+++ b/devices/autocloseabledevice.go
@@ -53,7 +53,7 @@ func NewAutoCloseableDevice(container DeviceContainer, uri *url.URL, deviceKey s
 	// }
 
 	var logger *log.Logger
-	if config.SniDebug {
+	if config.Config.GetBool("debug") {
 		defaultLogger := log.Default()
 		logger = log.New(
 			defaultLogger.Writer(),

--- a/devices/driver.go
+++ b/devices/driver.go
@@ -3,6 +3,9 @@ package devices
 import (
 	"fmt"
 	"net/url"
+	"os"
+	"sni/cmd/sni/config"
+	"sni/util"
 	"sort"
 	"sync"
 )
@@ -114,4 +117,20 @@ func DeviceByUri(uri *url.URL) (driver Driver, device AutoCloseableDevice, err e
 
 	device = driver.Device(uri)
 	return
+}
+
+// IsDisable returns a bool depending
+// default is false if no definition is found
+// Environment variable supersedes config file
+func IsDisabled(varName string) bool {
+	// read the Environment Variable
+	value, present := os.LookupEnv(varName)
+
+	if present {
+		return util.IsTruthy(value)
+	}
+
+	// else return what is the config file
+	// defaults to false if key not found
+	return config.Config.GetBool(varName)
 }

--- a/devices/driver.go
+++ b/devices/driver.go
@@ -119,10 +119,11 @@ func DeviceByUri(uri *url.URL) (driver Driver, device AutoCloseableDevice, err e
 	return
 }
 
-// IsDisable returns a bool depending
-// default is false if no definition is found
-// Environment variable supersedes config file
-func IsDisabled(varName string) bool {
+// IsDisable returns a bool
+// if an Environment variable is set, will return it's value
+// if value is set in config file, will return it's value
+// else returns default
+func IsDisabled(varName string, defaultValue bool) bool {
 	// read the Environment Variable
 	value, present := os.LookupEnv(varName)
 
@@ -132,5 +133,9 @@ func IsDisabled(varName string) bool {
 
 	// else return what is the config file
 	// defaults to false if key not found
-	return config.Config.GetBool(varName)
+	if config.Config.IsSet(varName) {
+		return config.Config.GetBool(varName)
+	}
+
+	return defaultValue
 }

--- a/devices/driver.go
+++ b/devices/driver.go
@@ -3,9 +3,6 @@ package devices
 import (
 	"fmt"
 	"net/url"
-	"os"
-	"sni/cmd/sni/config"
-	"sni/util"
 	"sort"
 	"sync"
 )
@@ -117,25 +114,4 @@ func DeviceByUri(uri *url.URL) (driver Driver, device AutoCloseableDevice, err e
 
 	device = driver.Device(uri)
 	return
-}
-
-// IsDisable returns a bool
-// if an Environment variable is set, will return it's value
-// if value is set in config file, will return it's value
-// else returns default
-func IsDisabled(varName string, defaultValue bool) bool {
-	// read the Environment Variable
-	value, present := os.LookupEnv(varName)
-
-	if present {
-		return util.IsTruthy(value)
-	}
-
-	// else return what is the config file
-	// defaults to false if key not found
-	if config.Config.IsSet(varName) {
-		return config.Config.GetBool(varName)
-	}
-
-	return defaultValue
 }

--- a/devices/snes/drivers/emunwa/driver.go
+++ b/devices/snes/drivers/emunwa/driver.go
@@ -232,6 +232,7 @@ func DriverInit() {
 		log.Printf("emunwa: unable to parse '%s', using default of 0xbeef (%d)\n", basePortStr, basePort)
 	}
 
+	log.Printf("emunwa: port range set to 0x%x", basePort)
 	disableOldRange := config.Config.GetBool("nwa_disable_old_range")
 
 	// comma-delimited list of host:port pairs:
@@ -274,6 +275,8 @@ func DriverInit() {
 	if config.Config.GetBool("emunw_detect_log") {
 		logDetector = true
 		log.Printf("emunwa: enabling emunwa detector logging")
+	} else {
+		log.Println("emunwa: disabling emunwa detector logging")
 	}
 
 	// register the driver:

--- a/devices/snes/drivers/emunwa/driver.go
+++ b/devices/snes/drivers/emunwa/driver.go
@@ -235,7 +235,7 @@ func DriverInit() {
 	disableOldRange := config.Config.GetBool("nwa_disable_old_range")
 
 	// comma-delimited list of host:port pairs:
-	hostsStr := env.GetOrSupply(config.Config.GetString("emunw_hosts"), func() string {
+	hostsStr := env.GetOrSupply("emunw_hosts", func() string {
 		const count = 10
 		hosts := make([]string, 0, 20)
 		if disableOldRange {

--- a/devices/snes/drivers/fxpakpro/driver.go
+++ b/devices/snes/drivers/fxpakpro/driver.go
@@ -222,7 +222,10 @@ func DriverInit() {
 		return
 	}
 
-	if config.Config.GetBool("sni_debug") {
+	log.Println("Enabling fxpakpro snes driver")
+
+	if config.Config.GetBool("debug") {
+		log.Println("Debug Mode Active")
 		defaultLogger := log.Default()
 		debugLog = log.New(
 			defaultLogger.Writer(),

--- a/devices/snes/drivers/fxpakpro/driver.go
+++ b/devices/snes/drivers/fxpakpro/driver.go
@@ -2,18 +2,18 @@ package fxpakpro
 
 import (
 	"fmt"
-	"go.bug.st/serial"
-	"go.bug.st/serial/enumerator"
 	"log"
 	"net/url"
 	"runtime"
+	"sni/cmd/sni/config"
 	"sni/devices"
 	"sni/protos/sni"
-	"sni/util"
-	"sni/util/env"
 	"strconv"
 	"strings"
 	"sync"
+
+	"go.bug.st/serial"
+	"go.bug.st/serial/enumerator"
 )
 
 const (
@@ -219,12 +219,12 @@ func (d *Driver) Device(uri *url.URL) devices.AutoCloseableDevice {
 var debugLog *log.Logger
 
 func DriverInit() {
-	if util.IsTruthy(env.GetOrDefault("SNI_FXPAKPRO_DISABLE", "0")) {
+	if devices.IsDisabled("SNI_FXPAKPRO_DISABLE") {
 		log.Printf("disabling fxpakpro snes driver\n")
 		return
 	}
 
-	if util.IsTruthy(env.GetOrDefault("SNI_DEBUG", "0")) {
+	if config.SniDebug {
 		defaultLogger := log.Default()
 		debugLog = log.New(
 			defaultLogger.Writer(),

--- a/devices/snes/drivers/fxpakpro/driver.go
+++ b/devices/snes/drivers/fxpakpro/driver.go
@@ -217,8 +217,6 @@ func (d *Driver) Device(uri *url.URL) devices.AutoCloseableDevice {
 var debugLog *log.Logger
 
 func DriverInit() {
-	// if devices.IsDisabled("SNI_FXPAKPRO_DISABLE", false) {
-	fmt.Printf("value: %v\n", config.Config.GetBool("fxpakpro_disable"))
 	if config.Config.GetBool("fxpakpro_disable") {
 		log.Printf("disabling fxpakpro snes driver\n")
 		return

--- a/devices/snes/drivers/fxpakpro/driver.go
+++ b/devices/snes/drivers/fxpakpro/driver.go
@@ -22,24 +22,22 @@ const (
 
 var driver *Driver
 
-var (
-	baudRates = []int{
-		921600, // first rate that works on Windows
-		460800,
-		256000,
-		230400, // first rate that works on MacOS
-		153600,
-		128000,
-		115200,
-		76800,
-		57600,
-		38400,
-		28800,
-		19200,
-		14400,
-		9600,
-	}
-)
+var baudRates = []int{
+	921600, // first rate that works on Windows
+	460800,
+	256000,
+	230400, // first rate that works on MacOS
+	153600,
+	128000,
+	115200,
+	76800,
+	57600,
+	38400,
+	28800,
+	19200,
+	14400,
+	9600,
+}
 
 const defaultAddressSpace = sni.AddressSpace_FxPakPro
 
@@ -157,9 +155,9 @@ func (d *Driver) openPort(portName string, baudRequest int) (f serial.Port, err 
 	}
 
 	// set DTR:
-	//log.Printf("serial: Set DTR on\n")
+	// log.Printf("serial: Set DTR on\n")
 	if err = f.SetDTR(true); err != nil {
-		//log.Printf("serial: %v\n", err)
+		// log.Printf("serial: %v\n", err)
 		_ = f.Close()
 		return nil, fmt.Errorf("%s: failed to set DTR: %w", driverName, err)
 	}
@@ -219,16 +217,18 @@ func (d *Driver) Device(uri *url.URL) devices.AutoCloseableDevice {
 var debugLog *log.Logger
 
 func DriverInit() {
-	if devices.IsDisabled("SNI_FXPAKPRO_DISABLE") {
+	// if devices.IsDisabled("SNI_FXPAKPRO_DISABLE", false) {
+	fmt.Printf("value: %v\n", config.Config.GetBool("fxpakpro_disable"))
+	if config.Config.GetBool("fxpakpro_disable") {
 		log.Printf("disabling fxpakpro snes driver\n")
 		return
 	}
 
-	if config.SniDebug {
+	if config.Config.GetBool("sni_debug") {
 		defaultLogger := log.Default()
 		debugLog = log.New(
 			defaultLogger.Writer(),
-			fmt.Sprintf("fxpakpro: "),
+			"fxpakpro: ",
 			defaultLogger.Flags()|log.Lmsgprefix,
 		)
 	}

--- a/devices/snes/drivers/fxpakpro/driver.go
+++ b/devices/snes/drivers/fxpakpro/driver.go
@@ -218,11 +218,9 @@ var debugLog *log.Logger
 
 func DriverInit() {
 	if config.Config.GetBool("fxpakpro_disable") {
-		log.Printf("disabling fxpakpro snes driver\n")
+		log.Printf("Disabling fxpakpro snes driver\n")
 		return
 	}
-
-	log.Println("Enabling fxpakpro snes driver")
 
 	if config.Config.GetBool("debug") {
 		log.Println("Debug Mode Active")
@@ -233,6 +231,8 @@ func DriverInit() {
 			defaultLogger.Flags()|log.Lmsgprefix,
 		)
 	}
+
+	log.Println("Enabling fxpakpro snes driver")
 
 	driver = &Driver{}
 	driver.container = devices.NewDeviceDriverContainer(driver.openDevice)

--- a/devices/snes/drivers/luabridge/driver.go
+++ b/devices/snes/drivers/luabridge/driver.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"sni/cmd/sni/config"
 	"sni/devices"
 	"sni/protos/sni"
 	"sni/util"
-	"sni/util/env"
 	"sync"
 	"time"
 )
@@ -221,8 +221,8 @@ func (d *Driver) runServer(listener *net.TCPListener) {
 }
 
 func DriverInit() {
-	bindHost = env.GetOrDefault("SNI_LUABRIDGE_LISTEN_HOST", "0.0.0.0")
-	bindPort = env.GetOrDefault("SNI_LUABRIDGE_LISTEN_PORT", "65398")
+	bindHost = config.Config.GetString("luabridge_listen_host")
+	bindPort = config.Config.GetString("luabridge_listen_port")
 	bindHostPort = net.JoinHostPort(bindHost, bindPort)
 
 	driver = &Driver{}

--- a/devices/snes/drivers/mock/driver.go
+++ b/devices/snes/drivers/mock/driver.go
@@ -3,10 +3,9 @@ package mock
 import (
 	"log"
 	"net/url"
+	"sni/cmd/sni/config"
 	"sni/devices"
 	"sni/protos/sni"
-	"sni/util"
-	"sni/util/env"
 )
 
 const driverName = "mock"
@@ -84,7 +83,7 @@ func (d *Driver) DisconnectAll() {
 }
 
 func DriverInit() {
-	if util.IsTruthy(env.GetOrDefault("SNI_MOCK_ENABLE", "0")) {
+	if config.Config.GetBool("mock_enable") {
 		log.Printf("enabling mock snes driver\n")
 		driver = &Driver{}
 		driver.container = devices.NewDeviceDriverContainer(driver.openDevice)

--- a/devices/snes/drivers/retroarch/driver.go
+++ b/devices/snes/drivers/retroarch/driver.go
@@ -2,11 +2,11 @@ package retroarch
 
 import (
 	"fmt"
-	"github.com/alttpo/snes/timing"
 	"log"
 	"net"
 	"net/url"
 	"runtime/debug"
+	"sni/cmd/sni/config"
 	"sni/devices"
 	"sni/protos/sni"
 	"sni/util"
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/alttpo/snes/timing"
 )
 
 const driverName = "ra"
@@ -198,13 +200,13 @@ func (d *Driver) DisconnectAll() {
 }
 
 func DriverInit() {
-	if devices.IsDisabled("SNI_RETROARCH_DISABLE", false) {
+	if config.Config.GetBool("retroarch_disable") {
 		log.Printf("disabling retroarch snes driver\n")
 		return
 	}
 
 	// comma-delimited list of host:port pairs:
-	hostsStr := env.GetOrSupply("SNI_RETROARCH_HOSTS", func() string {
+	hostsStr := env.GetOrSupply("retroarch_hosts", func() string {
 		// default network_cmd_port for RA is UDP 55355. we want to support connecting to multiple
 		// instances so let's auto-detect RA instances listening on UDP ports in the range
 		// [55355..55362]. realistically we probably won't be running any more than a few instances on

--- a/devices/snes/drivers/retroarch/driver.go
+++ b/devices/snes/drivers/retroarch/driver.go
@@ -9,7 +9,6 @@ import (
 	"sni/cmd/sni/config"
 	"sni/devices"
 	"sni/protos/sni"
-	"sni/util"
 	"sni/util/env"
 	"strings"
 	"sync"
@@ -239,7 +238,7 @@ func DriverInit() {
 		addresses = append(addresses, addr)
 	}
 
-	if util.IsTruthy(env.GetOrDefault("SNI_RETROARCH_DETECT_LOG", "0")) {
+	if config.Config.GetBool("retroarch_detect_log") {
 		logDetector = true
 		log.Printf("enabling retroarch detector logging")
 	}

--- a/devices/snes/drivers/retroarch/driver.go
+++ b/devices/snes/drivers/retroarch/driver.go
@@ -198,7 +198,7 @@ func (d *Driver) DisconnectAll() {
 }
 
 func DriverInit() {
-	if util.IsTruthy(env.GetOrDefault("SNI_RETROARCH_DISABLE", "0")) {
+	if devices.IsDisabled("SNI_RETROARCH_DISABLE", false) {
 		log.Printf("disabling retroarch snes driver\n")
 		return
 	}

--- a/services/grpcimpl/grpc.go
+++ b/services/grpcimpl/grpc.go
@@ -3,19 +3,19 @@ package grpcimpl
 import (
 	"context"
 	"fmt"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
-	"google.golang.org/grpc/reflection"
 	"log"
 	"net"
 	"net/http"
 	"sni/cmd/sni/config"
 	"sni/protos/sni"
 	"sni/util"
-	"sni/util/env"
 	"strconv"
 	"time"
+
+	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/reflection"
 )
 
 const fullMethodFormatter = "%32s"
@@ -27,7 +27,7 @@ var (
 
 func StartGrpcServer() {
 	// Parse env vars:
-	ListenHost = env.GetOrDefault("SNI_GRPC_LISTEN_HOST", "0.0.0.0")
+	ListenHost = config.Config.GetString("grpc_listen_host")
 
 	const maxMessageSize = 100 * 1024 * 1024 // 100 MB
 
@@ -35,7 +35,7 @@ func StartGrpcServer() {
 	GrpcServer = grpc.NewServer(
 		grpc.ChainUnaryInterceptor(logTimingInterceptor),
 		grpc.ChainStreamInterceptor(reportErrorStreamInterceptor),
-		grpc.MaxMsgSize(maxMessageSize),
+		grpc.MaxRecvMsgSize(maxMessageSize),
 	)
 	sni.RegisterDevicesServer(GrpcServer, &DevicesService{})
 	sni.RegisterDeviceMemoryServer(GrpcServer, &DeviceMemoryService{})
@@ -55,7 +55,7 @@ func serveGrpc() {
 	var err error
 
 	var listenPort int
-	listenPort, err = strconv.Atoi(env.GetOrDefault("SNI_GRPC_LISTEN_PORT", "8191"))
+	listenPort, err = strconv.Atoi(config.Config.GetString("grpc_listen_port"))
 	if err != nil {
 		listenPort = 8191
 	}
@@ -123,7 +123,7 @@ func serveGrpcWeb() {
 		_, _ = rw.Write(make([]byte, 0))
 	})
 
-	webListenPort := env.GetOrDefault("SNI_GRPCWEB_LISTEN_PORT", "8190")
+	webListenPort := config.Config.GetString("grpcweb_listen_port")
 	webListenAddr := net.JoinHostPort(ListenHost, webListenPort)
 
 	for {

--- a/services/usb2snes/usb2snes.go
+++ b/services/usb2snes/usb2snes.go
@@ -27,7 +27,7 @@ import (
 
 func StartHttpServer() {
 	if config.Config.GetBool("usb2snes_disable") {
-		log.Printf("usb2snes: server disabled due to env var %s=%s\n", "SNI_USB2SNES_DISABLE", true)
+		log.Printf("usb2snes: server disabled due to env var %s=%v\n", "SNI_USB2SNES_DISABLE", true)
 		return
 	}
 

--- a/services/usb2snes/usb2snes.go
+++ b/services/usb2snes/usb2snes.go
@@ -27,12 +27,12 @@ import (
 
 func StartHttpServer() {
 	if config.Config.GetBool("usb2snes_disable") {
-		log.Printf("usb2snes: server disabled due to env var %s=%v\n", "SNI_USB2SNES_DISABLE", true)
+		log.Printf("usb2snes: server disabled due to setting %s=%v\n", "SNI_USB2SNES_DISABLE", true)
 		return
 	}
 
 	// NOTE(jsd): 2024-01-25: retiring port 8080.
-	//addrList := env.GetOrDefault("SNI_USB2SNES_LISTEN_ADDRS", "0.0.0.0:23074,0.0.0.0:8080")
+	// addrList := env.GetOrDefault("SNI_USB2SNES_LISTEN_ADDRS", "0.0.0.0:23074,0.0.0.0:8080")
 	addrList := config.Config.GetString("usb2snes_listen_addrs")
 	listenAddrs := strings.Split(addrList, ",")
 	for _, listenAddr := range listenAddrs {
@@ -129,7 +129,7 @@ func (w *wsWriter) Write(p []byte) (n int, err error) {
 	}
 
 	if w.written >= w.frameSize {
-		//err = w.w.FlushFragment()
+		// err = w.w.FlushFragment()
 		err = w.w.Flush()
 		w.written = 0
 	}
@@ -551,7 +551,7 @@ serverLoop:
 				wsr := &wsReader{r: r}
 				n, err = wsr.Read(reqs[i].Data)
 				_ = n
-				//log.Printf("usb2snes: %s: %s read()[%d/%d]: read %d bytes; expected %d\n", clientName, cmd.Opcode, i+1, reqCount, n, size)
+				// log.Printf("usb2snes: %s: %s read()[%d/%d]: read %d bytes; expected %d\n", clientName, cmd.Opcode, i+1, reqCount, n, size)
 				if err != nil && err != io.EOF {
 					log.Printf("usb2snes: %s: %s read()[%d/%d]: %s\n", clientName, cmd.Opcode, i+1, reqCount, err)
 					break serverLoop

--- a/services/usb2snes/usb2snes.go
+++ b/services/usb2snes/usb2snes.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gobwas/ws"
-	"github.com/gobwas/ws/wsutil"
 	"io"
 	"log"
 	"net"
@@ -23,12 +21,15 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
 )
 
 func StartHttpServer() {
 	// Parse env vars:
-	disabled := env.GetOrDefault("SNI_USB2SNES_DISABLE", "0")
-	if util.IsTruthy(disabled) {
+	disabled := devices.IsDisabled("SNI_USB2SNES_DISABLE", false)
+	if disabled {
 		log.Printf("usb2snes: server disabled due to env var %s=%s\n", "SNI_USB2SNES_DISABLE", disabled)
 		return
 	}

--- a/services/usb2snes/usb2snes.go
+++ b/services/usb2snes/usb2snes.go
@@ -16,7 +16,6 @@ import (
 	"sni/devices/snes/mapping"
 	"sni/protos/sni"
 	"sni/util"
-	"sni/util/env"
 	"sni/util/hex"
 	"strconv"
 	"strings"
@@ -27,16 +26,14 @@ import (
 )
 
 func StartHttpServer() {
-	// Parse env vars:
-	disabled := devices.IsDisabled("SNI_USB2SNES_DISABLE", false)
-	if disabled {
-		log.Printf("usb2snes: server disabled due to env var %s=%s\n", "SNI_USB2SNES_DISABLE", disabled)
+	if config.Config.GetBool("usb2snes_disable") {
+		log.Printf("usb2snes: server disabled due to env var %s=%s\n", "SNI_USB2SNES_DISABLE", true)
 		return
 	}
 
 	// NOTE(jsd): 2024-01-25: retiring port 8080.
 	//addrList := env.GetOrDefault("SNI_USB2SNES_LISTEN_ADDRS", "0.0.0.0:23074,0.0.0.0:8080")
-	addrList := env.GetOrDefault("SNI_USB2SNES_LISTEN_ADDRS", "0.0.0.0:23074")
+	addrList := config.Config.GetString("usb2snes_listen_addrs")
 	listenAddrs := strings.Split(addrList, ",")
 	for _, listenAddr := range listenAddrs {
 		go func(listenAddr string) {

--- a/util/env/env.go
+++ b/util/env/env.go
@@ -3,6 +3,8 @@ package env
 import (
 	"log"
 	"os"
+	"sni/cmd/sni/config"
+	"strings"
 )
 
 func GetOrDefault(name string, defaultValue string) (value string) {
@@ -17,10 +19,10 @@ func GetOrDefault(name string, defaultValue string) (value string) {
 }
 
 func GetOrSupply(name string, defaultValueSupplier func() string) (value string) {
-	value = os.Getenv(name)
+	value = config.Config.GetString(name)
 	if value == "" {
 		value = defaultValueSupplier()
-		log.Printf("Read env var %s: not found; defaulting to '%s'\n", name, value)
+		log.Printf("Read env var SNI_%s: not found; defaulting to '%s'\n", strings.ToUpper(name), value)
 	} else {
 		log.Printf("Read env var %s: using '%s'\n", name, value)
 	}


### PR DESCRIPTION
Using viper's capabilities for the settings previously set through environment variables, to be set through the config file.

Environment variables maintain precedence over the config file.