### PR TITLE
Add Linux ARM64 builds and merge Linux+manylinux workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,8 +260,25 @@ jobs:
           #- os: ubuntu-latest
           #  goos: linux
           #  goarch: "386"
+          - os: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            goos: linux
+            goarch: amd64
+            gobuildenvs: 'CGO_LDFLAGS="$CGO_LDFLAGS -Wl,-rpath=\$ORIGIN -Wl,--gc-sections"'
+            suffix: tar.xz
+            tags: legacy_appindicator
+            os-variant: _manylinux_2_28
+          - os: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            goos: linux
+            goarch: arm64
+            gobuildenvs: 'CGO_LDFLAGS="$CGO_LDFLAGS -Wl,-rpath=\$ORIGIN -Wl,--gc-sections"'
+            suffix: tar.xz
+            tags: legacy_appindicator
+            os-variant: _manylinux_2_28
 
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Inject slug/short variables
@@ -272,8 +289,21 @@ jobs:
         with:
           go-version: '^1.22.1'
 
-      - name: Set up linux dependencies
+      - name: Set up linux dependencies (ubuntu)
+        if: ${{ !contains(matrix.os-variant, 'manylinux') }}
         run: sudo apt-get update && sudo apt-get install -y gcc ${{matrix.linuxdeps}}
+
+      - name: Set up linux dependencies (manylinux)
+        if: ${{ contains(matrix.os-variant, 'manylinux') }}
+        run: |
+          # manylinux_2_28 is based on alma 8
+          dnf -y install libappindicator-gtk3 libappindicator-gtk3-devel gtk3-devel libdbusmenu-gtk3 libdbusmenu-gtk3-devel
+
+      - name: Disable buildvcs
+        if: ${{ matrix.container }}
+        run: |
+          # when running go build in a container, buildvcs != false may fail
+          go env -w GOFLAGS=-buildvcs=false
 
       - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-${{matrix.goos}}${{matrix.os-variant}}-${{matrix.goarch}}${{matrix.alt}}" >> $GITHUB_ENV
 
@@ -299,14 +329,36 @@ jobs:
           cp lua/x64/socket-linux-5-4.so ${{env.basename}}/lua/x64/socket-linux-5-4.so
           cp lua/x64/socket-linux-5-1.so ${{env.basename}}/lua/x64/socket-linux-5-1.so
 
+      - name: Include appindicator
+        if: ${{ contains(matrix.os-variant, 'manylinux') }}
+        run: |
+          echo -e "\n--\nlibappindicator, libindicator and libdbusmenu are licensed under LGPL, see" >> ${{env.basename}}/LICENSE
+          echo "https://launchpad.net/libappindicator/" >> ${{env.basename}}/LICENSE
+          echo "https://launchpad.net/libindicator/" >> ${{env.basename}}/LICENSE
+          echo "https://launchpad.net/libdbusmenu/" >> ${{env.basename}}/LICENSE
+          cp -L /lib64/libappindicator3.so.1 ${{env.basename}}
+          cp -L /lib64/libindicator3.so.7 ${{env.basename}}
+          cp -L /lib64/libdbusmenu-glib.so.4 ${{env.basename}}
+          cp -L /lib64/libdbusmenu-gtk3.so.4 ${{env.basename}}
+
       - name: Build SNI
         run: >
-          CGO_ENABLED=1 GOOS=${{matrix.goos}} GOARCH=${{matrix.goarch}} ${{matrix.gobuildenvs}} go build
+          CGO_ENABLED=1
+          GOOS=${{matrix.goos}}
+          GOARCH=${{matrix.goarch}}
+          ${{matrix.gobuildenvs}}
+          go build
           -tags="${{ matrix.tags }}"
           -gcflags=all=-l
           -ldflags="-w -X 'main.version=${{env.GITHUB_REF_SLUG}}' -X 'main.commit=${{env.GITHUB_SHA_SHORT}}' -X 'main.date=$(date +'%Y-%m-%dT%H:%M:%S')'"
           -o ./${{env.basename}}/sni
           ./cmd/sni
+
+      - name: Patch appindicator rpath
+        if: ${{ contains(matrix.os-variant, 'manylinux') }}
+        run: |
+          dnf -y install patchelf
+          patchelf --force-rpath --set-rpath '$ORIGIN' ./${{env.basename}}/libappindicator3.*
 
       - name: Download SNFM
         if: ${{ matrix.snfm }}
@@ -337,107 +389,3 @@ jobs:
           overwrite: true
           asset_name: ${{env.basename}}.${{matrix.suffix}}
           file: ${{ github.workspace }}/${{env.basename}}.${{matrix.suffix}}
-
-  manylinux_2_28:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64
-            goos: linux
-            goarch: amd64
-            suffix: tar.xz
-            tags: legacy_appindicator
-          - os: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux_2_28_aarch64
-            goos: linux
-            goarch: arm64
-            suffix: tar.xz
-            tags: legacy_appindicator
-
-    runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
-
-    steps:
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '^1.22.1'
-
-      - name: Set up linux dependencies
-        run: |
-          # manylinux_2_28 is based on alma 8
-          dnf -y install libappindicator-gtk3 libappindicator-gtk3-devel gtk3-devel libdbusmenu-gtk3 libdbusmenu-gtk3-devel
-
-      - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-manylinux_2_28-${{matrix.goarch}}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
-        name: Checkout
-        with:
-          fetch-depth: 0
-
-      - name: Collect files
-        run: |
-          mkdir ${{env.basename}}
-          mkdir ${{env.basename}}/lua
-          cp README.md ${{env.basename}}
-          cp LICENSE ${{env.basename}}
-          cp protos/sni/sni.proto ${{env.basename}}
-          cp cmd/sni/apps.yaml ${{env.basename}}
-          cp lua/Connector.lua ${{env.basename}}/lua
-          echo -e "\n--\nlibappindicator, libindicator and libdbusmenu are licensed under LGPL, see" >> ${{env.basename}}/LICENSE
-          echo "https://launchpad.net/libappindicator/" >> ${{env.basename}}/LICENSE
-          echo "https://launchpad.net/libindicator/" >> ${{env.basename}}/LICENSE
-          echo "https://launchpad.net/libdbusmenu/" >> ${{env.basename}}/LICENSE
-          cp -L /lib64/libappindicator3.so.1 ${{env.basename}}
-          cp -L /lib64/libindicator3.so.7 ${{env.basename}}
-          cp -L /lib64/libdbusmenu-glib.so.4 ${{env.basename}}
-          cp -L /lib64/libdbusmenu-gtk3.so.4 ${{env.basename}}
-
-      - name: Lua connector (x64)
-        if: ${{ matrix.goarch == 'amd64' }}
-        run: |
-          mkdir ${{env.basename}}/lua/x64
-          cp lua/x64/socket-linux-5-4.so ${{env.basename}}/lua/x64/socket-linux-5-4.so
-          cp lua/x64/socket-linux-5-1.so ${{env.basename}}/lua/x64/socket-linux-5-1.so
-
-      - name: Build SNI
-        run: >
-          CGO_ENABLED=1
-          CGO_LDFLAGS="$CGO_LDFLAGS -Wl,-rpath=\$ORIGIN -Wl,--gc-sections"
-          GOARCH=${{matrix.goarch}}
-          go build -tags=${{matrix.tags}} -buildvcs=false
-          -gcflags=all=-l
-          -ldflags="-w -X 'main.version=${{env.GITHUB_REF_SLUG}}' -X 'main.commit=${{env.GITHUB_SHA_SHORT}}' -X 'main.date=$(date +'%Y-%m-%dT%H:%M:%S')'"
-          -o ./${{env.basename}}/sni
-          ./cmd/sni
-
-      - name: Patch appindicator rpath
-        run: |
-          dnf -y install patchelf
-          patchelf --force-rpath --set-rpath '$ORIGIN' ./${{env.basename}}/libappindicator3.*
-
-      - name: Package ${{env.basename}}.${{matrix.suffix}} for Linux
-        run: |
-          ldd ${{env.basename}}/sni
-          tar cJf ${{env.basename}}.${{matrix.suffix}} ${{env.basename}}/
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{env.basename}}.${{matrix.suffix}}
-          path: ${{github.workspace}}/${{env.basename}}.${{matrix.suffix}}
-
-      - name: Upload binaries to release
-        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.GITHUB_REF_SLUG }}
-          overwrite: true
-          asset_name: ${{env.basename}}.${{matrix.suffix}}
-          file: ${{github.workspace}}/${{env.basename}}.${{matrix.suffix}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,34 +246,22 @@ jobs:
             tags: notray
             alt: -notray
             snfm: snfm-*-linux-x64.zip
-          ## NOTE(2023-08-31): disabled arm64 builds due to cross-compilation error with systray package:
-          ## # github.com/getlantern/systray
-          ## In file included from /usr/aarch64-linux-gnu/include/features.h:510,
-          ##                  from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33,
-          ##                  from /usr/aarch64-linux-gnu/include/stdlib.h:26,
-          ##                  from _cgo_export.c:3:
-          ## /usr/include/x86_64-linux-gnu/gnu/stubs.h:7:11: fatal error: gnu/stubs-32.h: No such file or directory
-          ##     7 | # include <gnu/stubs-32.h>
-          ##       |           ^~~~~~~~~~~~~~~~
-          ## compilation terminated.
-          #- os: ubuntu-latest
-          #  goos: linux
-          #  goarch: arm64
-          #  suffix: tar.xz
-          #  linuxdeps: gcc-aarch64-linux-gnu libgtk-3-dev libayatana-appindicator3-dev
-          #  gobuildenvs: CC=aarch64-linux-gnu-gcc
-          #- os: ubuntu-latest
-          #  goos: linux
-          #  goarch: arm64
-          #  suffix: tar.xz
-          #  tags: notray
-          #  alt: -notray
-          #  linuxdeps: gcc-aarch64-linux-gnu
-          #  gobuildenvs: CC=aarch64-linux-gnu-gcc
+          - os: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+            suffix: tar.xz
+            linuxdeps: libgtk-3-dev libayatana-appindicator3-dev
+          - os: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+            suffix: tar.xz
+            tags: notray
+            alt: -notray
           #- os: ubuntu-latest
           #  goos: linux
           #  goarch: "386"
-    runs-on: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Inject slug/short variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,8 +351,26 @@ jobs:
           file: ${{ github.workspace }}/${{env.basename}}.${{matrix.suffix}}
 
   manylinux_2_28:
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_28_x86_64
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            goos: linux
+            goarch: amd64
+            suffix: tar.xz
+            tags: legacy_appindicator
+          - os: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            goos: linux
+            goarch: arm64
+            suffix: tar.xz
+            tags: legacy_appindicator
+
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+
     steps:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -367,7 +385,7 @@ jobs:
           # manylinux_2_28 is based on alma 8
           dnf -y install libappindicator-gtk3 libappindicator-gtk3-devel gtk3-devel libdbusmenu-gtk3 libdbusmenu-gtk3-devel
 
-      - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-manylinux_2_28-amd64" >> $GITHUB_ENV
+      - run: echo "basename=sni-${{env.GITHUB_REF_SLUG}}-manylinux_2_28-${{matrix.goarch}}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         name: Checkout
@@ -378,14 +396,11 @@ jobs:
         run: |
           mkdir ${{env.basename}}
           mkdir ${{env.basename}}/lua
-          mkdir ${{env.basename}}/lua/x64
           cp README.md ${{env.basename}}
           cp LICENSE ${{env.basename}}
           cp protos/sni/sni.proto ${{env.basename}}
           cp cmd/sni/apps.yaml ${{env.basename}}
           cp lua/Connector.lua ${{env.basename}}/lua
-          cp lua/x64/socket-linux-5-1.so ${{env.basename}}/lua/x64/socket-linux-5-1.so
-          cp lua/x64/socket-linux-5-4.so ${{env.basename}}/lua/x64/socket-linux-5-4.so
           echo -e "\n--\nlibappindicator, libindicator and libdbusmenu are licensed under LGPL, see" >> ${{env.basename}}/LICENSE
           echo "https://launchpad.net/libappindicator/" >> ${{env.basename}}/LICENSE
           echo "https://launchpad.net/libindicator/" >> ${{env.basename}}/LICENSE
@@ -395,12 +410,19 @@ jobs:
           cp -L /lib64/libdbusmenu-glib.so.4 ${{env.basename}}
           cp -L /lib64/libdbusmenu-gtk3.so.4 ${{env.basename}}
 
+      - name: Lua connector (x64)
+        if: ${{ matrix.goarch == 'amd64' }}
+        run: |
+          mkdir ${{env.basename}}/lua/x64
+          cp lua/x64/socket-linux-5-4.so ${{env.basename}}/lua/x64/socket-linux-5-4.so
+          cp lua/x64/socket-linux-5-1.so ${{env.basename}}/lua/x64/socket-linux-5-1.so
+
       - name: Build SNI
         run: >
           CGO_ENABLED=1
           CGO_LDFLAGS="$CGO_LDFLAGS -Wl,-rpath=\$ORIGIN -Wl,--gc-sections"
-          GOARCH=amd64
-          go build -tags=legacy_appindicator -buildvcs=false
+          GOARCH=${{matrix.goarch}}
+          go build -tags=${{matrix.tags}} -buildvcs=false
           -gcflags=all=-l
           -ldflags="-w -X 'main.version=${{env.GITHUB_REF_SLUG}}' -X 'main.commit=${{env.GITHUB_SHA_SHORT}}' -X 'main.date=$(date +'%Y-%m-%dT%H:%M:%S')'"
           -o ./${{env.basename}}/sni
@@ -411,16 +433,16 @@ jobs:
           dnf -y install patchelf
           patchelf --force-rpath --set-rpath '$ORIGIN' ./${{env.basename}}/libappindicator3.*
 
-      - name: Package ${{env.basename}}.tar.xz for Linux
+      - name: Package ${{env.basename}}.${{matrix.suffix}} for Linux
         run: |
           ldd ${{env.basename}}/sni
-          tar cJf ${{env.basename}}.tar.xz ${{env.basename}}/
+          tar cJf ${{env.basename}}.${{matrix.suffix}} ${{env.basename}}/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{env.basename}}.tar.xz
-          path: ${{github.workspace}}/${{env.basename}}.tar.xz
+          name: ${{env.basename}}.${{matrix.suffix}}
+          path: ${{github.workspace}}/${{env.basename}}.${{matrix.suffix}}
 
       - name: Upload binaries to release
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
@@ -429,5 +451,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.GITHUB_REF_SLUG }}
           overwrite: true
-          asset_name: ${{env.basename}}.tar.xz
-          file: ${{github.workspace}}/${{env.basename}}.tar.xz
+          asset_name: ${{env.basename}}.${{matrix.suffix}}
+          file: ${{github.workspace}}/${{env.basename}}.${{matrix.suffix}}


### PR DESCRIPTION
Tested on a raspberry pi5 with 64bit raspi os.
With the new default desktop environment (wayland), neither libatatata nor libappindicator shows a tray icon. This can be worked around by switching back to the X11-based desktop environment.

Also merged the linux and manylinux jobs since it's easier to keep them in sync this way.
Maybe we should also merge windows and macos in the future.