### PR TITLE
proxy: Add SNI proxy driver for forwarding gRPC to a remote SNI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,25 +56,26 @@ it assumes if they are not set.
 
 The following environment variables are defined:
 
-| Name                      | Default                              | Purpose                                                                                                                                                 |
-|---------------------------|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SNI_DEBUG                 | 0                                    | enable debug logging                                                                                                                                    |
-| SNI_GRPC_LISTEN_HOST      | 0.0.0.0                              | grpc: host to listen on for gRPC connections                                                                                                            |
-| SNI_GRPC_LISTEN_PORT      | 8191                                 | grpc: port to listen on for gRPC connections                                                                                                            |
-| SNI_GRPCWEB_LISTEN_PORT   | 8190                                 | grpc-web: port to listen on for gRPC-Web connections (WebSockets support for gRPC)                                                                      |
-| SNI_USB2SNES_DISABLE      | 0                                    | usb2snes: set to 1 to disable usb2snes server                                                                                                           |
-| SNI_USB2SNES_LISTEN_ADDRS | 0.0.0.0:23074                        | usb2snes: comma-delimited list of host:ports to listen on                                                                                               |
-| SNI_FXPAKPRO_DISABLE      | 0                                    | fxpakpro: set to 1 to disable FX Pak Pro driver                                                                                                         |
-| SNI_RETROARCH_DISABLE     | 0                                    | retroarch: set to 1 to disable Retroarch driver                                                                                                         |
-| SNI_RETROARCH_HOSTS       | localhost:55355                      | retroarch: list of comma-delimited host:port pairs to detect retroarch instances on; configure these with `network_cmd_port` setting in `retroarch.cfg` |
-| SNI_RETROARCH_DETECT_LOG  | 0                                    | retroarch: set to 1 to enable logging of RA emulator detection                                                                                          |
-| SNI_LUABRIDGE_LISTEN_HOST | 127.0.0.1                            | luabridge: host/IP to listen on                                                                                                                         |
-| SNI_LUABRIDGE_LISTEN_PORT | 65398                                | luabridge: port number to listen on                                                                                                                     |
-| SNI_EMUNW_DISABLE         | 0                                    | nwa: set to 1 to disable emunwa protocol                                                                                                                |
-| SNI_EMUNW_DETECT_LOG      | 0                                    | nwa: set to 1 to enable logging of emulator detection                                                                                                   |
-| SNI_EMUNW_HOSTS           | localhost:48879,...,localhost:48888  | nwa: comma-delimited list of host:port pairs to scan for nwa-enabled emulators                                                                          |
-| NWA_PORT_RANGE            | 48879                                | nwa: default starting port number for port range (0xbeef)                                                                                               |
-| NWA_DISABLE_OLD_RANGE     | 1                                    | nwa: set to 1 to disable deprecated port range 65400..65409                                                                                             |
+| Name                      | Default                              | Purpose                                                                                                                                                   |
+|---------------------------|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SNI_DEBUG                 | 0                                    | enable debug logging                                                                                                                                      |
+| SNI_GRPC_LISTEN_HOST      | 0.0.0.0                              | grpc: host to listen on for gRPC connections                                                                                                              |
+| SNI_GRPC_LISTEN_PORT      | 8191                                 | grpc: port to listen on for gRPC connections                                                                                                              |
+| SNI_GRPCWEB_LISTEN_PORT   | 8190                                 | grpc-web: port to listen on for gRPC-Web connections (WebSockets support for gRPC)                                                                        |
+| SNI_USB2SNES_DISABLE      | 0                                    | usb2snes: set to 1 to disable usb2snes server                                                                                                             |
+| SNI_USB2SNES_LISTEN_ADDRS | 0.0.0.0:23074                        | usb2snes: comma-delimited list of host:ports to listen on                                                                                                 |
+| SNI_FXPAKPRO_DISABLE      | 0                                    | fxpakpro: set to 1 to disable FX Pak Pro driver                                                                                                           |
+| SNI_RETROARCH_DISABLE     | 0                                    | retroarch: set to 1 to disable Retroarch driver                                                                                                           |
+| SNI_RETROARCH_HOSTS       | localhost:55355                      | retroarch: list of comma-delimited host:port pairs to detect retroarch instances on; configure these with `network_cmd_port` setting in `retroarch.cfg`   |
+| SNI_RETROARCH_DETECT_LOG  | 0                                    | retroarch: set to 1 to enable logging of RA emulator detection                                                                                            |
+| SNI_LUABRIDGE_LISTEN_HOST | 127.0.0.1                            | luabridge: host/IP to listen on                                                                                                                           |
+| SNI_LUABRIDGE_LISTEN_PORT | 65398                                | luabridge: port number to listen on                                                                                                                       |
+| SNI_EMUNW_DISABLE         | 0                                    | nwa: set to 1 to disable emunwa protocol                                                                                                                  |
+| SNI_EMUNW_DETECT_LOG      | 0                                    | nwa: set to 1 to enable logging of emulator detection                                                                                                     |
+| SNI_EMUNW_HOSTS           | localhost:48879,...,localhost:48888  | nwa: comma-delimited list of host:port pairs to scan for nwa-enabled emulators                                                                            |
+| NWA_PORT_RANGE            | 48879                                | nwa: default starting port number for port range (0xbeef)                                                                                                 |
+| NWA_DISABLE_OLD_RANGE     | 1                                    | nwa: set to 1 to disable deprecated port range 65400..65409                                                                                               |
+| SNI_PROXY_BACKEND_HOST    |                                      | proxy: host:port of remote SNI instance to proxy requests to.  For example, to use with [SNES on a Mister](https://github.com/MiSTer-devel/SNES_MiSTer)   |
 
 ### USB2SNES Compatibility
 

--- a/cmd/sni/config/config.go
+++ b/cmd/sni/config/config.go
@@ -63,6 +63,9 @@ var (
 		// We are not setting it here
 		"emunw_disable":    false,
 		"emunw_detect_log": false,
+
+		"proxy_disable":       false,
+		"proxy_backend_host":  "",
 	}
 	nwaConfigs = map[string]any{
 		"nwa_port_range":        NwaDefaultPort,

--- a/cmd/sni/main.go
+++ b/cmd/sni/main.go
@@ -15,6 +15,7 @@ import (
 	"sni/devices/snes/drivers/fxpakpro"
 	"sni/devices/snes/drivers/luabridge"
 	"sni/devices/snes/drivers/mock"
+	"sni/devices/snes/drivers/proxy"
 	"sni/devices/snes/drivers/retroarch"
 	"sni/services/grpcimpl"
 	"sni/services/usb2snes"
@@ -94,6 +95,7 @@ func main() {
 	luabridge.DriverInit()
 	retroarch.DriverInit()
 	mock.DriverInit()
+	proxy.DriverInit()
 
 	// start the servers:
 	grpcimpl.StartGrpcServer()

--- a/devices/snes/drivers/proxy/device.go
+++ b/devices/snes/drivers/proxy/device.go
@@ -1,0 +1,438 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sni/devices"
+	"sni/protos/sni"
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+// Device proxies all device operations to a remote SNI gRPC server.
+type Device struct {
+	lock sync.Mutex
+
+	conn      *grpc.ClientConn
+	remoteURI string
+
+	devices    sni.DevicesClient
+	memory     sni.DeviceMemoryClient
+	control    sni.DeviceControlClient
+	filesystem sni.DeviceFilesystemClient
+	info       sni.DeviceInfoClient
+	nwa        sni.DeviceNWAClient
+
+	closed bool
+}
+
+func (d *Device) IsClosed() bool {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return d.closed
+}
+
+func (d *Device) Close() error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.closed = true
+	if d.conn != nil {
+		return d.conn.Close()
+	}
+	return nil
+}
+
+// DeviceMemory implementation
+
+func (d *Device) RequiresMemoryMappingForAddressSpace(_ context.Context, addressSpace sni.AddressSpace) (bool, error) {
+	if addressSpace == sni.AddressSpace_FxPakPro {
+		return false, nil
+	}
+	if addressSpace == sni.AddressSpace_Raw {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (d *Device) RequiresMemoryMappingForAddress(_ context.Context, address devices.AddressTuple) (bool, error) {
+	if address.AddressSpace == sni.AddressSpace_FxPakPro {
+		return false, nil
+	}
+	if address.AddressSpace == sni.AddressSpace_Raw {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (d *Device) MultiReadMemory(ctx context.Context, reads ...devices.MemoryReadRequest) ([]devices.MemoryReadResponse, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return nil, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	requests := make([]*sni.ReadMemoryRequest, 0, len(reads))
+	for _, read := range reads {
+		requests = append(requests, &sni.ReadMemoryRequest{
+			RequestAddress:       read.RequestAddress.Address,
+			RequestAddressSpace:  read.RequestAddress.AddressSpace,
+			RequestMemoryMapping: read.RequestAddress.MemoryMapping,
+			Size:                 uint32(read.Size),
+		})
+	}
+
+	resp, err := d.memory.MultiRead(ctx, &sni.MultiReadMemoryRequest{
+		Uri:      d.remoteURI,
+		Requests: requests,
+	})
+	if err != nil {
+		return nil, devices.DeviceFatal("proxy: MultiRead failed", err)
+	}
+
+	responses := make([]devices.MemoryReadResponse, 0, len(resp.GetResponses()))
+	for _, r := range resp.GetResponses() {
+		responses = append(responses, devices.MemoryReadResponse{
+			RequestAddress: devices.AddressTuple{
+				Address:       r.GetRequestAddress(),
+				AddressSpace:  r.GetRequestAddressSpace(),
+				MemoryMapping: r.GetRequestMemoryMapping(),
+			},
+			DeviceAddress: devices.AddressTuple{
+				Address:       r.GetDeviceAddress(),
+				AddressSpace:  r.GetDeviceAddressSpace(),
+				MemoryMapping: r.GetRequestMemoryMapping(),
+			},
+			Data: r.GetData(),
+		})
+	}
+
+	return responses, nil
+}
+
+func (d *Device) MultiWriteMemory(ctx context.Context, writes ...devices.MemoryWriteRequest) ([]devices.MemoryWriteResponse, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return nil, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	requests := make([]*sni.WriteMemoryRequest, 0, len(writes))
+	for _, write := range writes {
+		requests = append(requests, &sni.WriteMemoryRequest{
+			RequestAddress:       write.RequestAddress.Address,
+			RequestAddressSpace:  write.RequestAddress.AddressSpace,
+			RequestMemoryMapping: write.RequestAddress.MemoryMapping,
+			Data:                 write.Data,
+		})
+	}
+
+	resp, err := d.memory.MultiWrite(ctx, &sni.MultiWriteMemoryRequest{
+		Uri:      d.remoteURI,
+		Requests: requests,
+	})
+	if err != nil {
+		return nil, devices.DeviceFatal("proxy: MultiWrite failed", err)
+	}
+
+	responses := make([]devices.MemoryWriteResponse, 0, len(resp.GetResponses()))
+	for _, r := range resp.GetResponses() {
+		responses = append(responses, devices.MemoryWriteResponse{
+			RequestAddress: devices.AddressTuple{
+				Address:       r.GetRequestAddress(),
+				AddressSpace:  r.GetRequestAddressSpace(),
+				MemoryMapping: r.GetRequestMemoryMapping(),
+			},
+			DeviceAddress: devices.AddressTuple{
+				Address:       r.GetDeviceAddress(),
+				AddressSpace:  r.GetDeviceAddressSpace(),
+				MemoryMapping: r.GetRequestMemoryMapping(),
+			},
+			Size: int(r.GetSize()),
+		})
+	}
+
+	return responses, nil
+}
+
+// DeviceControl implementation
+
+func (d *Device) ResetSystem(ctx context.Context) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	_, err := d.control.ResetSystem(ctx, &sni.ResetSystemRequest{
+		Uri: d.remoteURI,
+	})
+	if err != nil {
+		return devices.DeviceFatal("proxy: ResetSystem failed", err)
+	}
+	return nil
+}
+
+func (d *Device) ResetToMenu(ctx context.Context) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	_, err := d.control.ResetToMenu(ctx, &sni.ResetToMenuRequest{
+		Uri: d.remoteURI,
+	})
+	if err != nil {
+		return devices.DeviceFatal("proxy: ResetToMenu failed", err)
+	}
+	return nil
+}
+
+func (d *Device) PauseUnpause(ctx context.Context, pausedState bool) (bool, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return false, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	resp, err := d.control.PauseUnpauseEmulation(ctx, &sni.PauseEmulationRequest{
+		Uri:    d.remoteURI,
+		Paused: pausedState,
+	})
+	if err != nil {
+		return false, devices.DeviceFatal("proxy: PauseUnpause failed", err)
+	}
+	return resp.GetPaused(), nil
+}
+
+func (d *Device) PauseToggle(ctx context.Context) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	_, err := d.control.PauseToggleEmulation(ctx, &sni.PauseToggleEmulationRequest{
+		Uri: d.remoteURI,
+	})
+	if err != nil {
+		return devices.DeviceFatal("proxy: PauseToggle failed", err)
+	}
+	return nil
+}
+
+// DeviceFilesystem implementation
+
+func (d *Device) ReadDirectory(ctx context.Context, path string) ([]devices.DirEntry, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return nil, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	resp, err := d.filesystem.ReadDirectory(ctx, &sni.ReadDirectoryRequest{
+		Uri:  d.remoteURI,
+		Path: path,
+	})
+	if err != nil {
+		return nil, devices.DeviceFatal("proxy: ReadDirectory failed", err)
+	}
+
+	entries := make([]devices.DirEntry, 0, len(resp.GetEntries()))
+	for _, entry := range resp.GetEntries() {
+		entries = append(entries, devices.DirEntry{
+			Name: entry.GetName(),
+			Type: entry.GetType(),
+		})
+	}
+	return entries, nil
+}
+
+func (d *Device) MakeDirectory(ctx context.Context, path string) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	_, err := d.filesystem.MakeDirectory(ctx, &sni.MakeDirectoryRequest{
+		Uri:  d.remoteURI,
+		Path: path,
+	})
+	if err != nil {
+		return devices.DeviceFatal("proxy: MakeDirectory failed", err)
+	}
+	return nil
+}
+
+func (d *Device) RemoveFile(ctx context.Context, path string) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	_, err := d.filesystem.RemoveFile(ctx, &sni.RemoveFileRequest{
+		Uri:  d.remoteURI,
+		Path: path,
+	})
+	if err != nil {
+		return devices.DeviceFatal("proxy: RemoveFile failed", err)
+	}
+	return nil
+}
+
+func (d *Device) RenameFile(ctx context.Context, path, newFilename string) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	_, err := d.filesystem.RenameFile(ctx, &sni.RenameFileRequest{
+		Uri:      d.remoteURI,
+		Path:     path,
+		NewFilename: newFilename,
+	})
+	if err != nil {
+		return devices.DeviceFatal("proxy: RenameFile failed", err)
+	}
+	return nil
+}
+
+func (d *Device) PutFile(ctx context.Context, path string, size uint32, r io.Reader, progress devices.ProgressReportFunc) (uint32, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return 0, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return 0, devices.DeviceNonFatal("proxy: failed to read file data", err)
+	}
+
+	resp, err := d.filesystem.PutFile(ctx, &sni.PutFileRequest{
+		Uri:  d.remoteURI,
+		Path: path,
+		Data: data,
+	})
+	if err != nil {
+		return 0, devices.DeviceFatal("proxy: PutFile failed", err)
+	}
+
+	return resp.GetSize(), nil
+}
+
+func (d *Device) GetFile(ctx context.Context, path string, w io.Writer, sizeReceived devices.SizeReceivedFunc, progress devices.ProgressReportFunc) (uint32, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return 0, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	resp, err := d.filesystem.GetFile(ctx, &sni.GetFileRequest{
+		Uri:  d.remoteURI,
+		Path: path,
+	})
+	if err != nil {
+		return 0, devices.DeviceFatal("proxy: GetFile failed", err)
+	}
+
+	data := resp.GetData()
+	size := uint32(len(data))
+
+	if sizeReceived != nil {
+		sizeReceived(size)
+	}
+
+	n, err := io.Copy(w, bytes.NewReader(data))
+	if err != nil {
+		return uint32(n), devices.DeviceNonFatal("proxy: failed to write file data", err)
+	}
+
+	return size, nil
+}
+
+func (d *Device) BootFile(ctx context.Context, path string) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	_, err := d.filesystem.BootFile(ctx, &sni.BootFileRequest{
+		Uri:  d.remoteURI,
+		Path: path,
+	})
+	if err != nil {
+		return devices.DeviceFatal("proxy: BootFile failed", err)
+	}
+	return nil
+}
+
+// DeviceInfo implementation
+
+func (d *Device) FetchFields(ctx context.Context, fields ...sni.Field) ([]string, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return nil, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	resp, err := d.info.FetchFields(ctx, &sni.FieldsRequest{
+		Uri:    d.remoteURI,
+		Fields: fields,
+	})
+	if err != nil {
+		return nil, devices.DeviceFatal("proxy: FetchFields failed", err)
+	}
+
+	return resp.GetValues(), nil
+}
+
+// DeviceNWA implementation
+
+func (d *Device) NWACommand(ctx context.Context, cmd string, args string, binaryArg []byte) ([]map[string]string, []byte, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.closed {
+		return nil, nil, devices.DeviceFatal("proxy: device is closed", nil)
+	}
+
+	resp, err := d.nwa.NWACommand(ctx, &sni.NWACommandRequest{
+		Uri:       d.remoteURI,
+		Command:   cmd,
+		Args:      args,
+		BinaryArg: binaryArg,
+	})
+	if err != nil {
+		return nil, nil, devices.DeviceFatal("proxy: NWACommand failed", err)
+	}
+
+	// convert proto reply to map slice
+	asciiReply := make([]map[string]string, 0, len(resp.GetAsciiReply()))
+	for _, item := range resp.GetAsciiReply() {
+		asciiReply = append(asciiReply, item.GetItem())
+	}
+
+	return asciiReply, resp.GetBinaryReplay(), nil
+}

--- a/devices/snes/drivers/proxy/driver.go
+++ b/devices/snes/drivers/proxy/driver.go
@@ -1,0 +1,198 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"sni/cmd/sni/config"
+	"sni/devices"
+	"sni/protos/sni"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const driverName = "proxy"
+
+var driver *Driver
+
+const defaultAddressSpace = sni.AddressSpace_SnesABus
+
+// Driver implements the devices.Driver interface for proxying gRPC requests
+// to a remote SNI server.
+type Driver struct {
+	container devices.DeviceContainer
+
+	// backendAddr is the host:port of the remote SNI gRPC server to proxy to
+	backendAddr string
+}
+
+func (d *Driver) DisplayOrder() int {
+	return 100
+}
+
+func (d *Driver) DisplayName() string {
+	return "SNI Proxy"
+}
+
+func (d *Driver) DisplayDescription() string {
+	return "Proxy connections to a remote SNI gRPC server"
+}
+
+func (d *Driver) Kind() string { return driverName }
+
+// driverCapabilities lists all capabilities that a proxied device could support.
+// The actual capabilities are determined by the remote device and reported through Detect().
+var driverCapabilities = []sni.DeviceCapability{
+	sni.DeviceCapability_ReadMemory,
+	sni.DeviceCapability_WriteMemory,
+	sni.DeviceCapability_ResetSystem,
+	sni.DeviceCapability_ResetToMenu,
+	sni.DeviceCapability_PauseUnpauseEmulation,
+	sni.DeviceCapability_PauseToggleEmulation,
+	sni.DeviceCapability_FetchFields,
+	sni.DeviceCapability_ReadDirectory,
+	sni.DeviceCapability_MakeDirectory,
+	sni.DeviceCapability_RemoveFile,
+	sni.DeviceCapability_RenameFile,
+	sni.DeviceCapability_PutFile,
+	sni.DeviceCapability_GetFile,
+	sni.DeviceCapability_BootFile,
+	sni.DeviceCapability_NWACommand,
+}
+
+func (d *Driver) HasCapabilities(capabilities ...sni.DeviceCapability) (bool, error) {
+	return devices.CheckCapabilities(capabilities, driverCapabilities)
+}
+
+func (d *Driver) Detect() (devs []devices.DeviceDescriptor, err error) {
+	// connect to backend SNI server to discover its devices
+	conn, cerr := grpc.NewClient(
+		d.backendAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if cerr != nil {
+		log.Printf("proxy: failed to connect to backend %s: %v\n", d.backendAddr, cerr)
+		return nil, nil
+	}
+	defer conn.Close()
+
+	client := sni.NewDevicesClient(conn)
+
+	ctx, cancel := newDetectContext()
+	defer cancel()
+
+	resp, rerr := client.ListDevices(ctx, &sni.DevicesRequest{})
+	if rerr != nil {
+		log.Printf("proxy: failed to list devices from backend %s: %v\n", d.backendAddr, rerr)
+		return nil, nil
+	}
+
+	devs = make([]devices.DeviceDescriptor, 0, len(resp.GetDevices()))
+
+	for _, dev := range resp.GetDevices() {
+		// build a proxy URI that encodes both the backend address and the remote device URI
+		// format: proxy://<backendAddr>?uri=<remoteDeviceUri>
+		proxyURI := url.URL{
+			Scheme:   driverName,
+			Host:     d.backendAddr,
+			RawQuery: "uri=" + url.QueryEscape(dev.GetUri()),
+		}
+
+		descriptor := devices.DeviceDescriptor{
+			Uri:                 proxyURI,
+			DisplayName:         fmt.Sprintf("[Proxy] %s", dev.GetDisplayName()),
+			Kind:                driverName,
+			Capabilities:        dev.GetCapabilities(),
+			DefaultAddressSpace: dev.GetDefaultAddressSpace(),
+			System:              "snes",
+		}
+
+		devs = append(devs, descriptor)
+	}
+
+	return
+}
+
+func (d *Driver) DeviceKey(uri *url.URL) string {
+	return uri.Host + "?" + uri.RawQuery
+}
+
+func (d *Driver) Device(uri *url.URL) devices.AutoCloseableDevice {
+	return devices.NewAutoCloseableDevice(d.container, uri, d.DeviceKey(uri))
+}
+
+func (d *Driver) openDevice(uri *url.URL) (devices.Device, error) {
+	backendAddr := uri.Host
+	remoteURI := uri.Query().Get("uri")
+	if remoteURI == "" {
+		return nil, fmt.Errorf("proxy: missing 'uri' query parameter in device URI")
+	}
+
+	conn, err := grpc.NewClient(
+		backendAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, devices.DeviceFatal(
+			fmt.Sprintf("proxy: failed to connect to backend %s", backendAddr),
+			err,
+		)
+	}
+
+	dev := &Device{
+		conn:      conn,
+		remoteURI: remoteURI,
+		devices:   sni.NewDevicesClient(conn),
+		memory:    sni.NewDeviceMemoryClient(conn),
+		control:   sni.NewDeviceControlClient(conn),
+		filesystem: sni.NewDeviceFilesystemClient(conn),
+		info:      sni.NewDeviceInfoClient(conn),
+		nwa:       sni.NewDeviceNWAClient(conn),
+	}
+
+	return dev, nil
+}
+
+func (d *Driver) DisconnectAll() {
+	for _, deviceKey := range d.container.AllDeviceKeys() {
+		device, ok := d.container.GetDevice(deviceKey)
+		if ok {
+			log.Printf("%s: disconnecting device '%s'\n", driverName, deviceKey)
+			_ = device.Close()
+			d.container.DeleteDevice(deviceKey)
+		}
+	}
+}
+
+func newDetectContext() (ctx_out context.Context, cancel context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
+}
+
+func DriverInit() {
+	if config.Config.GetBool("proxy_disable") {
+		log.Printf("disabling proxy snes driver\n")
+		return
+	}
+
+	backendAddr := config.Config.GetString("proxy_backend_host")
+	if backendAddr == "" {
+		// proxy driver not configured, silently skip
+		return
+	}
+
+	// support multiple comma-separated backend addresses in the future;
+	// for now just trim whitespace
+	backendAddr = strings.TrimSpace(backendAddr)
+
+	log.Printf("proxy: enabling proxy driver to backend %s\n", backendAddr)
+
+	driver = &Driver{
+		backendAddr: backendAddr,
+	}
+	driver.container = devices.NewDeviceDriverContainer(driver.openDevice)
+	devices.Register(driverName, driver)
+}

--- a/devices/snes/drivers/proxy/driver.go
+++ b/devices/snes/drivers/proxy/driver.go
@@ -144,14 +144,14 @@ func (d *Driver) openDevice(uri *url.URL) (devices.Device, error) {
 	}
 
 	dev := &Device{
-		conn:      conn,
-		remoteURI: remoteURI,
-		devices:   sni.NewDevicesClient(conn),
-		memory:    sni.NewDeviceMemoryClient(conn),
-		control:   sni.NewDeviceControlClient(conn),
+		conn:       conn,
+		remoteURI:  remoteURI,
+		devices:    sni.NewDevicesClient(conn),
+		memory:     sni.NewDeviceMemoryClient(conn),
+		control:    sni.NewDeviceControlClient(conn),
 		filesystem: sni.NewDeviceFilesystemClient(conn),
-		info:      sni.NewDeviceInfoClient(conn),
-		nwa:       sni.NewDeviceNWAClient(conn),
+		info:       sni.NewDeviceInfoClient(conn),
+		nwa:        sni.NewDeviceNWAClient(conn),
 	}
 
 	return dev, nil
@@ -184,8 +184,7 @@ func DriverInit() {
 		return
 	}
 
-	// support multiple comma-separated backend addresses in the future;
-	// for now just trim whitespace
+	// TODO: consider supporting an array / multiple comma-separated backend addresses in the future
 	backendAddr = strings.TrimSpace(backendAddr)
 
 	log.Printf("proxy: enabling proxy driver to backend %s\n", backendAddr)


### PR DESCRIPTION
Adds a `proxy` driver that discovers and proxies devices from a remote SNI instance. Web apps connect to localhost; the proxy forwards all gRPC operations to a remote host that is also exposing an SNI interface.  Implemented with a Mister running the latest unstable SNES core in mind.

### New: `devices/snes/drivers/proxy/`

- **`driver.go`** — `Detect()` calls `ListDevices` on the remote backend and re-exposes each device under a `proxy://<backend>?uri=<encoded_remote_uri>` scheme. Follows the standard `Driver`/`DriverDescriptor`/`DeviceContainer` pattern.
- **`device.go`** — Implements all device interfaces (`DeviceMemory`, `DeviceControl`, `DeviceFilesystem`, `DeviceInfo`, `DeviceNWA`) by forwarding each call to the backend via generated gRPC clients. Errors wrapped with `DeviceFatal` for auto-reconnect.

### Config (`cmd/sni/config/config.go`)

- `proxy_backend_host` — `host:port` of the remote SNI gRPC server (e.g. `192.168.1.100:8191`). Driver only registers when set.
- `proxy_disable` — explicitly disable the driver.

### Registration (`cmd/sni/main.go`)

- `proxy.DriverInit()` added alongside existing drivers.

### Usage

```yaml
# ~/.sni/config.yaml
proxy_backend_host: "192.168.1.100:8191"
```

Devices on the remote host then appear locally as `[Proxy] RetroArch v1.x (...)` etc., addressable through the standard SNI gRPC/gRPC-web APIs.