### PR TITLE
Package Mesen-S version of connector in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           cp LICENSE ${{env.basename}}
           cp protos/sni/sni.proto ${{env.basename}}
           cp cmd/sni/apps.yaml ${{env.basename}}
-          cp lua/Connector.lua ${{env.basename}}/lua
+          cp lua/{,MesenS}Connector.lua ${{env.basename}}/lua
 
       - name: Copy in lua socket.dll dependencies for Windows
         run: |
@@ -183,7 +183,7 @@ jobs:
           cp LICENSE ${{env.basename}}
           cp protos/sni/sni.proto ${{env.basename}}
           cp cmd/sni/apps.yaml ${{env.basename}}
-          cp lua/Connector.lua ${{env.basename}}/lua
+          cp lua/{,MesenS}Connector.lua ${{env.basename}}/lua
 
       - name: Build SNI (amd64, arm64)
         run: >
@@ -305,7 +305,7 @@ jobs:
           cp LICENSE ${{env.basename}}
           cp protos/sni/sni.proto ${{env.basename}}
           cp cmd/sni/apps.yaml ${{env.basename}}
-          cp lua/Connector.lua ${{env.basename}}/lua
+          cp lua/{,MesenS}Connector.lua ${{env.basename}}/lua
 
       - name: Copy in lua socket.so dependencies for Linux amd64
         if: ${{ matrix.goarch == 'amd64' }}
@@ -387,7 +387,7 @@ jobs:
           cp LICENSE ${{env.basename}}
           cp protos/sni/sni.proto ${{env.basename}}
           cp cmd/sni/apps.yaml ${{env.basename}}
-          cp lua/Connector.lua ${{env.basename}}/lua
+          cp lua/{,MesenS}Connector.lua ${{env.basename}}/lua
           cp lua/x64/socket-linux-5-1.so ${{env.basename}}/lua/x64/socket-linux-5-1.so
           cp lua/x64/socket-linux-5-4.so ${{env.basename}}/lua/x64/socket-linux-5-4.so
           echo -e "\n--\nlibdbusmenu is licensed under LGPL, see" >> ${{env.basename}}/LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,6 @@ jobs:
 
       - name: Copy in lua socket.dll dependencies for Windows
         run: |
-          rm ${{env.basename}}/lua/Connector.lua
-          cp lua/Connector.lua ${{env.basename}}/lua/
           cp lua/x64/socket-windows-5-1.dll ${{env.basename}}/lua/x64
           cp lua/x64/socket-windows-5-4.dll ${{env.basename}}/lua/x64
           cp lua/x64/luasocket.LICENSE.txt ${{env.basename}}/lua/x64


### PR DESCRIPTION
I've been using this script with MesenCE, but since it's not included in the release tarballs, downstream distributions (Archipelago, wink wink nudge nudge) don't distribute it and Mesen support is obscure. (This is meant as a first step to fix that, after this PR is accepted :crossed_fingers: there'll be more coordination work :P)

I also got confused by some redundant file ops, investigated for a minute, and concluded they could be removed. So that's a bonus commit (ideally, don't squash this PR!)

Cheers o/